### PR TITLE
Fix the pako.min.js url

### DIFF
--- a/external-player.user.js
+++ b/external-player.user.js
@@ -18,7 +18,7 @@
 // @grant                   GM_getValue
 // @grant                   GM.xmlHttpRequest
 // @run-at                  document-start
-// @require                 https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-y/pako/2.0.4/pako.min.js
+// @require                 https://cdnjs.cloudflare.com/ajax/libs/pako/2.0.4/pako.min.js
 // ==/UserScript==
 
 'use strict';


### PR DESCRIPTION
The original URL turned out to be 404, so I replaced it with Cloudflare cdnjs. Otherwise, the script will throw a "pako not found" error when redirecting the videoes.